### PR TITLE
Add support for public IP capture from multiple clouds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Changed
 - moved config options from Vagrantfile to new config.yaml
+- Retrieving the IP from metadata can now be extended with multiple clouds
 
 ## [16.04-1.0.0]
 ### Changed

--- a/provisioning/4.server.sh
+++ b/provisioning/4.server.sh
@@ -7,6 +7,7 @@ KEY_DIR="${RSA_DIR}/keys"
 
 prep_rsa() {
     cd "${RSA_DIR}" || exit
+    # shellcheck disable=SC1091
     . ./vars
 }
 

--- a/provisioning/5.client.sh
+++ b/provisioning/5.client.sh
@@ -38,6 +38,7 @@ CLIENT_CONFIGS='/vagrant/client-configs'
 
 prep_rsa() {
     cd "${RSA_DIR}" || exit
+    # shellcheck disable=SC1091
     . ./vars
 }
 

--- a/provisioning/5.client.sh
+++ b/provisioning/5.client.sh
@@ -17,7 +17,21 @@ while getopts ":c:f" opt; do
 done
 shift $((OPTIND-1))
 
-IPADDR=$(curl -s http://169.254.169.254/metadata/v1/interfaces/public/0/ipv4/address)
+ipaddr() {
+    URLS=( http://169.254.169.254/metadata/v1/interfaces/public/0/ipv4/address )
+
+    for i in "${URLS[@]}"; do
+        status_code=$(curl -o /dev/null --silent --head --write-out '%{http_code}\n' "${i}")
+        if [ "${status_code}" -ne '404' ]; then
+            ip_addr=$(curl -s "${i}")
+            break
+        fi
+    done
+
+    echo "${ip_addr}"
+}
+
+IPADDR=$(ipaddr)
 RSA_DIR='/root/openvpn-ca'
 KEY_DIR="${RSA_DIR}/keys"
 CLIENT_CONFIGS='/vagrant/client-configs'


### PR DESCRIPTION
Currently digital ocean metadata is hardcoded for public IP address retrieval. This PR adds support for the addition of multiple cloud providers in the future.